### PR TITLE
Add accessible hand-drawn pie chart and React wrapper

### DIFF
--- a/.github/agent.md
+++ b/.github/agent.md
@@ -135,6 +135,40 @@ Built from the controls above; one `seed` covers every stroke, `destroy()` remov
 
 React: `DrawablyChip`, `DrawablyTabs` (`active`), `DrawablyTooltip` (`to` ref), `DrawablyAlert`, `DrawablySteps`, `DrawablyKbd`, `DrawablyQuote`, `DrawablyPager` (`active`).
 
+## Pie chart
+
+`drawablyPieChart(el, { data, showLegend?, ...sketchOptions })` appends a square
+responsive plot and a native HTML legend. `DrawablyPieChart` is the React
+counterpart; pass `data` and sketch options as props. It renders a div and
+accepts native div props except children and dangerouslySetInnerHTML.
+
+```js
+const chart = drawablyPieChart(el, {
+  data: [{ label: "A", value: 60 }, { label: "B", value: 40 }, { label: "C", value: 0 }],
+  seed: 42, boil: 0, showLegend: true,
+});
+chart.setData([{ label: "A", value: 25 }, { label: "B", value: 75 }]);
+chart.resketch(7);
+chart.destroy();
+```
+
+- Required `data`: `{ label: string, value: number, color?: string }[]` of
+  finite non-negative weights; normalized automatically. Invalid input throws.
+- All-zero/empty data shows “No data”. Zero values remain in the legend without
+  slices. A single positive value draws a circle without a radial seam.
+- `showLegend` defaults true; false visually hides the HTML legend but keeps
+  it accessible. SVG and interior percentage labels are decorative. Small
+  wedges omit interior labels; every percentage remains in the legend.
+- Values display at most one decimal; positive shares under 0.1% say `<0.1%`.
+- Set chart width with CSS on the host; the `width` option is stroke thickness.
+- Per-item `color` sets a CSS custom property, accepts `var(...)`. Otherwise
+  theme `--drawably-series-1` through `--drawably-series-6`; the palette cycles.
+- `setData` keeps the seed; `destroy` removes owned DOM, resize observers and
+  font listeners, preserving existing host content. React updates on data changes.
+- `roughPieSlice(cx, cy, radius, startAngle, endAngle, opts)` is a public path
+  generator. Angles are clockwise radians from the positive x axis. Zero radius
+  or non-positive sweep returns an empty path; a full turn returns a circle.
+
 ## Text decoration
 
 Decorates existing inline text; the element keeps its own layout. Use on a word or short phrase — a phrase that wraps gets one box, not one per line.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Hand-drawn UI controls. Every mount generates a fresh pen sketch from seeded
 randomness, and the stroke boils like an animated doodle. Zero dependencies,
-~9 KB of JS gzipped (React wrappers add under 1 KB) and a 3 KB stylesheet. An
+~12 KB of compiled core modules gzipped (React wrappers add ~1.3 KB) and a
+~3.3 KB gzipped stylesheet. An
 optional pen font is a separate 31 KB.
 
 ![Buttons, checkbox, radio and toggle drawn in a boiling pen stroke](assets/demo.svg)
@@ -95,6 +96,58 @@ Every control has a React counterpart in `drawably/react`: `DrawablyButton`,
 `DrawablyCheckbox`, `DrawablyRadio`, `DrawablyToggle`, `DrawablyInput`,
 `DrawablyTextarea`, `DrawablySelect`, `DrawablyDivider`, `DrawablyCard`,
 `DrawablyBadge`, `DrawablyList`.
+
+## Pie chart
+
+`drawablyPieChart(el, opts)` appends a responsive, scribble-filled pie chart and
+an HTML legend to a block element. The host controls its width; the plot
+reserves a square before drawing. The SVG is decorative and the HTML legend
+exposes every label and percentage to screen readers, including zero values.
+
+```js
+import { drawablyPieChart } from "drawably";
+import "drawably/style.css";
+
+const data = [
+  { label: "Overexcitement and frustration", value: 60 },
+  { label: "Learned habit", value: 40 },
+  { label: "Fear", value: 0 },
+  { label: "Aggression", value: 0 },
+];
+const chart = drawablyPieChart(document.querySelector("#reasons"), {
+  data, seed: 42, roughness: 1, boil: 0, showLegend: true,
+});
+chart.setData(data); // update values without changing the sketch seed
+chart.resketch(7);
+chart.destroy(); // removes only the chart's own content and observers
+```
+
+React uses the same options and updates when `data` changes:
+
+```jsx
+import { DrawablyPieChart } from "drawably/react";
+
+<DrawablyPieChart data={data} seed={42} boil={0} showLegend aria-label="Reasons" />
+```
+
+- `data` is required: an array of `{ label, value, color? }`. Values are finite,
+  non-negative weights, normalized to percentages; they need not total 100.
+  Negative/non-finite values throw before modifying the chart.
+- `showLegend` defaults to `true`. When false, the legend remains available to
+  screen readers. Small slices omit interior labels to avoid collisions.
+- Zero values have legend entries but no slices. Empty/all-zero data displays
+  “No data”; a single positive value draws a full circle.
+- Per-item `color` accepts a CSS colour or `var(...)`. Alternatively, set
+  `--drawably-series-1` through `--drawably-series-6` on the host or an ancestor.
+  Colours cycle after six items; labels always identify the categories.
+- The standard `seed`, `roughness`, `boil`, `stroke`, `paper`, and `width` options
+  apply. `width` is pen-stroke thickness, not chart width. `boil: 0` is static;
+  reduced-motion preferences freeze the existing CSS animation automatically.
+- Percentages are rounded to one decimal; tiny positive shares display
+  `<0.1%`. Rounded percentages may not add to exactly 100.
+
+See [the pie chart example](examples/pie-chart.html). The optional
+`drawably/font.css` registers Drawably Pen; the chart inherits the host font.
 
 ## Text decoration
 
@@ -216,7 +269,7 @@ const frames = variants(
 // three path strings — render them and cycle opacity
 ```
 
-Also exported: `roughEllipse`, `roughArrow`, `roughCheckmark`, `scribbleFill`,
+Also exported: `roughEllipse`, `roughArrow`, `roughCheckmark`, `roughPieSlice`, `scribbleFill`,
 and the seeded PRNG `mulberry32` with `randomSeed`.
 
 ## License

--- a/examples/index.html
+++ b/examples/index.html
@@ -784,6 +784,14 @@
         </ol>
       </nav>
 
+      <section class="board" id="charts" aria-label="Pie chart">
+        <div>
+          <h2>Pie chart</h2>
+          <div id="pie-chart" style="width: min(100%, 340px)"></div>
+          <p><a href="./pie-chart.html">Open the interactive pie chart example</a></p>
+        </div>
+      </section>
+
       <section class="board" id="install" aria-label="Install">
         <div class="brand">
           <div class="cmd-wrap" id="install-card">
@@ -1043,6 +1051,7 @@
 
     <script type="module">
       import {
+        drawablyPieChart,
         drawablyArrow,
         drawablyBadge,
         drawablyButton,
@@ -1060,6 +1069,10 @@
         drawablyUnderline,
       } from "../dist/index.js";
 
+      drawablyPieChart(document.getElementById("pie-chart"), {
+        data: [{ label: "Overexcitement and frustration", value: 60 }, { label: "Learned habit", value: 40 }, { label: "Fear", value: 0 }, { label: "Aggression", value: 0 }],
+        seed: 42, boil: 0,
+      });
       drawablyButton(document.getElementById("done"), { variant: "solid" });
       drawablyButton(document.getElementById("cancel"), { tone: "neutral" });
       drawablyButton(document.getElementById("save"), { variant: "scribble" });

--- a/examples/pie-chart.html
+++ b/examples/pie-chart.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Drawably · Pie chart</title>
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../font/font.css">
+  <style>
+    * { box-sizing: border-box; }
+    :root { color-scheme: light; --drawably-paper: #e3e3e1; --drawably-stroke: #2724d1; }
+    body { margin: 0; padding: 40px 24px; background: var(--drawably-paper); color: #34322e; font: 18px/1.5 "Drawably Pen", system-ui, sans-serif; }
+    main { max-width: 900px; margin: auto; }
+    h1 { font: inherit; font-size: 42px; margin: 0; color: #2724d1; }
+    .intro { margin: 6px 0 32px; }
+    .layout { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 64px; align-items: start; }
+    #chart { max-width: 380px; width: 100%; margin: auto; }
+    h2 { font: inherit; font-size: 25px; margin: 0 0 18px; }
+    .values { display: grid; grid-template-columns: minmax(0,1fr) 70px; gap: 14px 18px; align-items: center; }
+    label { min-width: 0; }
+    input[type=number] { font: inherit; width: 100%; padding: 5px 7px; border: 1px solid #77716a; border-radius: 3px; background: transparent; color: inherit; }
+    .actions { display: flex; flex-wrap: wrap; gap: 14px; margin: 24px 0; }
+    .drawably-button { font: inherit; }
+    .check { display: flex; align-items: center; gap: 8px; margin: 12px 0; }
+    .note { font-size: 16px; margin: 24px 0 0; }
+    #error { color: #b32220; }
+    @media(max-width:680px) { body { padding: 24px 18px; } .layout { grid-template-columns: minmax(0,1fr); gap: 36px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>A pie chart, in pen.</h1>
+    <p class="intro">Drawably's own strokes. Your data.</p>
+    <div class="layout">
+      <div id="chart" aria-label="Reasons"></div>
+      <section aria-labelledby="edit-title">
+        <h2 id="edit-title">Make it yours</h2>
+        <form id="data-form">
+          <div class="values">
+            <label for="excitement">Overexcitement and frustration</label><input id="excitement" type="number" min="0" step="any" value="60" required>
+            <label for="habit">Learned habit</label><input id="habit" type="number" min="0" step="any" value="40" required>
+            <label for="fear">Fear</label><input id="fear" type="number" min="0" step="any" value="0" required>
+            <label for="aggression">Aggression</label><input id="aggression" type="number" min="0" step="any" value="0" required>
+          </div>
+          <div class="actions"><button id="update" type="submit">Update chart</button><button id="resketch" type="button">Re-sketch</button></div>
+          <p id="error" role="alert" hidden></p>
+        </form>
+        <label class="check"><input id="boil" type="checkbox"> Animate pen strokes</label>
+        <label class="check"><input id="legend" type="checkbox" checked> Show legend</label>
+        <p id="status" class="note" aria-live="polite">Values are converted to percentages. Zero values stay in the legend.</p>
+      </section>
+    </div>
+  </main>
+  <script type="module">
+    import { drawablyPieChart, drawablyButton, randomSeed } from '../dist/index.js';
+    const labels = ['Overexcitement and frustration', 'Learned habit', 'Fear', 'Aggression'];
+    const ids = ['excitement', 'habit', 'fear', 'aggression'];
+    const host = document.getElementById('chart');
+    const boil = document.getElementById('boil'), legend = document.getElementById('legend');
+    const error = document.getElementById('error'), status = document.getElementById('status');
+    let data = labels.map((label,i) => ({ label, value: document.getElementById(ids[i]).valueAsNumber }));
+    let seed = 42, chart;
+    function attach() { chart?.destroy(); chart = drawablyPieChart(host, { data, seed, boil: boil.checked ? .3 : 0, showLegend: legend.checked }); }
+    attach();
+    for (const id of ['update','resketch']) drawablyButton(document.getElementById(id), { seed: 42, boil: 0 });
+    document.getElementById('data-form').addEventListener('submit', event => {
+      event.preventDefault();
+      const next = labels.map((label,i) => ({ label, value: document.getElementById(ids[i]).valueAsNumber }));
+      try { chart.setData(next); data = next; error.hidden = true; status.textContent = 'Chart updated.'; }
+      catch (e) { error.textContent = e.message; error.hidden = false; }
+    });
+    document.getElementById('resketch').addEventListener('click', () => { seed = randomSeed(); chart.resketch(seed); });
+    boil.addEventListener('change', attach);
+    legend.addEventListener('change', attach);
+  </script>
+</body>
+</html>

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -6,6 +6,7 @@ import {
   roughCircle,
   roughEllipse,
   roughLine,
+  roughPieSlice,
   roughRoundedRect,
   scribbleFill,
   variants,
@@ -220,6 +221,171 @@ export function drawablyCard(el: HTMLElement, opts: DrawablyOptions = {}): Sketc
   const sketch = attachChrome(el, [{ className: "drawably-outline", gen: outlineRect(10) }], opts, false);
   el.classList.add("drawably-card");
   return sketch;
+}
+
+export interface DrawablyPieDatum {
+  label: string;
+  value: number;
+  /** CSS colour, including var(...); otherwise uses --drawably-series-1 through -6. */
+  color?: string;
+}
+
+export interface DrawablyPieChartOptions extends DrawablyOptions {
+  data: readonly DrawablyPieDatum[];
+  showLegend?: boolean;
+}
+
+export interface PieChartSketch extends Sketch {
+  setData(data: readonly DrawablyPieDatum[]): void;
+}
+
+let pieId = 0;
+const PIE_TURN = Math.PI * 2;
+const PIE_PALETTE = ["var(--drawably-stroke, #2724d1)", "#0f766e", "#b45309", "#8852aa", "#d12724", "#6e675f"];
+
+function pieData(data: readonly DrawablyPieDatum[]): DrawablyPieDatum[] {
+  if (!Array.isArray(data) || data.some(d => !d || typeof d.label !== "string" ||
+    typeof d.value !== "number" || !Number.isFinite(d.value) || d.value < 0 ||
+    (d.color !== undefined && typeof d.color !== "string")))
+    throw new Error("drawably: pie data requires labels and finite, non-negative values");
+  return data.map(d => ({ ...d }));
+}
+
+function piePercent(share: number): string {
+  if (share > 0 && share < 0.001) return "<0.1%";
+  return `${Math.round(share * 1000) / 10}%`;
+}
+
+/** Appends an owned plot and native HTML legend; preserves existing host content. */
+export function drawablyPieChart(el: HTMLElement, opts: DrawablyPieChartOptions): PieChartSketch {
+  if (!(el instanceof HTMLElement)) throw new Error("drawably: expected an HTMLElement");
+  let data = pieData(opts?.data);
+  const roughness = opts.roughness ?? 1, boil = opts.boil ?? 0.3;
+  if (![roughness, boil, opts.width ?? 2].every(v => Number.isFinite(v) && v >= 0))
+    throw new Error("drawably: pie roughness, boil and width must be finite and non-negative");
+  let seed = opts.seed ?? randomSeed(), destroyed = false;
+  const id = `drawably-pie-${++pieId}`;
+  const wrapper = document.createElement("div");
+  wrapper.className = "drawably-pie-chart";
+  applyTheme(wrapper, opts);
+  const plot = document.createElement("div");
+  plot.className = "drawably-host drawably-pie-plot";
+  const svg = createSvg();
+  svg.setAttribute("focusable", "false");
+  plot.append(svg);
+  const legend = document.createElement("ul");
+  legend.className = opts.showLegend === false ? "drawably-pie-legend drawably-pie-hidden" : "drawably-pie-legend";
+  legend.setAttribute("aria-label", "Chart data");
+  wrapper.append(plot, legend);
+  el.append(wrapper);
+
+  function draw() {
+    if (destroyed) return;
+    // The HTML plot reserves its square before SVG exists, including hidden mounts.
+    const size = plot.clientWidth || 300;
+    const center = size / 2;
+    const inset = Math.max(INSET, roughness * 3 + boil + (opts.width ?? 2));
+    const radius = Math.max(0, center - inset);
+    svg.setAttribute("viewBox", `0 0 ${size} ${size}`);
+    svg.replaceChildren();
+    plot.querySelectorAll(".drawably-pie-label, .drawably-pie-empty").forEach(n => n.remove());
+    legend.replaceChildren();
+    const defs = document.createElementNS(SVG_NS, "defs");
+    svg.append(defs);
+    // Scaling before summation also accepts finite values whose raw total overflows.
+    const max = data.reduce((m, d) => Math.max(m, d.value), 0);
+    const total = max ? data.reduce((s, d) => s + d.value / max, 0) : 0;
+    let start = -Math.PI / 2;
+
+    data.forEach((datum, index) => {
+      const share = total ? (datum.value / max) / total : 0;
+      const slot = index % PIE_PALETTE.length;
+      const color = datum.color ?? `var(--drawably-series-${slot + 1}, ${PIE_PALETTE[slot]})`;
+      const item = document.createElement("li");
+      const swatch = document.createElement("span");
+      swatch.className = "drawably-pie-swatch";
+      swatch.style.setProperty("--drawably-ink", color);
+      swatch.setAttribute("aria-hidden", "true");
+      const label = document.createElement("span");
+      label.textContent = `${datum.label}: ${piePercent(share)}`;
+      item.append(swatch, label);
+      legend.append(item);
+      if (!share || !radius) return;
+      const end = start + share * PIE_TURN;
+      const group = document.createElementNS(SVG_NS, "g");
+      group.classList.add("drawably-pie-slice");
+      group.dataset.index = String(index);
+      group.style.setProperty("--drawably-ink", color);
+      const clip = document.createElementNS(SVG_NS, "clipPath");
+      clip.id = `${id}-${index}`;
+      clip.setAttribute("clipPathUnits", "userSpaceOnUse");
+      // Exact geometry clips the scribble; randomness changes only its pen strokes.
+      if (share === 1) {
+        const circle = document.createElementNS(SVG_NS, "circle");
+        circle.setAttribute("cx", String(center)); circle.setAttribute("cy", String(center));
+        circle.setAttribute("r", String(radius)); clip.append(circle);
+      } else {
+        const path = document.createElementNS(SVG_NS, "path");
+        path.setAttribute("d", `M${center} ${center} L${center + radius * Math.cos(start)} ${center + radius * Math.sin(start)} A${radius} ${radius} 0 ${share > 0.5 ? 1 : 0} 1 ${center + radius * Math.cos(end)} ${center + radius * Math.sin(end)} Z`);
+        clip.append(path);
+      }
+      defs.append(clip);
+      const hatch = document.createElementNS(SVG_NS, "g");
+      hatch.setAttribute("clip-path", `url(#${clip.id})`);
+      group.append(hatch);
+      const o = { seed: seed + index, roughness, boil };
+      const layers = [
+        { parent: hatch, cls: "drawably-scribble", gen: (ro: RoughOptions) => scribbleFill(center - radius, center - radius, radius * 2, radius * 2, ro) },
+        { parent: group, cls: "drawably-outline", gen: (ro: RoughOptions) => roughPieSlice(center, center, radius, start, end, ro) },
+      ];
+      for (const layer of layers) {
+        const frames = variants(layer.gen, o, boil ? 3 : 1);
+        frames.forEach((d, i) => {
+          const path = document.createElementNS(SVG_NS, "path");
+          path.setAttribute("d", d);
+          path.setAttribute("class", `${layer.cls}${boil ? " drawably-boil" : ""}`);
+          path.dataset.i = String(i);
+          layer.parent.append(path);
+        });
+      }
+      svg.append(group);
+      // Only label wedges with room for a 3em percentage; every value stays in HTML.
+      const mid = (start + end) / 2, labelRadius = share === 1 ? 0 : radius * 0.62;
+      const labelWidth = (parseFloat(getComputedStyle(plot).fontSize) || 16) * 3;
+      if (share === 1 || (share >= 0.08 && labelRadius * (end - start) >= labelWidth)) {
+        const value = document.createElement("span");
+        value.className = "drawably-pie-label";
+        value.setAttribute("aria-hidden", "true");
+        value.textContent = piePercent(share);
+        value.style.left = `${(center + labelRadius * Math.cos(mid)) / size * 100}%`;
+        value.style.top = `${(center + labelRadius * Math.sin(mid)) / size * 100}%`;
+        plot.append(value);
+      }
+      start = end;
+    });
+    if (!total) {
+      const empty = document.createElement("span");
+      empty.className = "drawably-pie-empty";
+      empty.textContent = "No data";
+      plot.append(empty);
+    }
+  }
+  draw();
+  const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(draw);
+  observer?.observe(plot);
+  // A late opt-in font can change which labels fit without changing the plot's box.
+  const fonts = document.fonts;
+  fonts?.addEventListener("loadingdone", draw);
+  return {
+    resketch(nextSeed) { if (!destroyed) { seed = nextSeed ?? randomSeed(); draw(); } },
+    setData(nextData) { if (!destroyed) { data = pieData(nextData); draw(); } },
+    destroy() {
+      destroyed = true;
+      observer?.disconnect();
+      fonts?.removeEventListener("loadingdone", draw);
+      wrapper.remove();
+    },
+  };
 }
 
 function syncedControl(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
   drawablyHighlight,
   drawablyInput,
   drawablyList,
+  drawablyPieChart,
   drawablyRadio,
   drawablySelect,
   drawablyTextarea,
@@ -20,6 +21,9 @@ export {
   type DrawablyButtonState,
   type DrawablyListOptions,
   type DrawablyOptions,
+  type DrawablyPieDatum,
+  type DrawablyPieChartOptions,
+  type PieChartSketch,
   type Sketch,
 } from "./controls.js";
 export {
@@ -43,6 +47,7 @@ export {
   roughCircle,
   roughEllipse,
   roughLine,
+  roughPieSlice,
   roughRoundedRect,
   scribbleFill,
   variants,

--- a/src/react.ts
+++ b/src/react.ts
@@ -13,6 +13,8 @@ import {
   type DrawablyButtonOptions,
   type DrawablyListOptions,
   type DrawablyOptions,
+  type DrawablyPieChartOptions,
+  type PieChartSketch,
   drawablyArrow,
   drawablyBadge,
   drawablyButton,
@@ -23,6 +25,7 @@ import {
   drawablyHighlight,
   drawablyInput,
   drawablyList,
+  drawablyPieChart,
   drawablyRadio,
   drawablySelect,
   drawablyTextarea,
@@ -129,6 +132,18 @@ export function DrawablyCard({ seed, roughness, boil, stroke, fill, paper, width
 }
 
 type SpanProps = DrawablyOptions & ComponentProps<"span">;
+
+export type DrawablyPieChartProps = DrawablyPieChartOptions & Omit<ComponentProps<"div">, "children" | "dangerouslySetInnerHTML">;
+
+export function DrawablyPieChart({ data, showLegend, seed, roughness, boil, stroke, fill, paper, width, className, ...rest }: DrawablyPieChartProps): ReactElement {
+  const sketchRef = useRef<PieChartSketch | null>(null);
+  const ref = useSketch<HTMLDivElement>(
+    el => (sketchRef.current = drawablyPieChart(el, { data, showLegend, seed, roughness, boil, stroke, fill, paper, width })),
+    [showLegend, seed, roughness, boil, stroke, fill, paper, width, className],
+  );
+  useEffect(() => { sketchRef.current?.setData(data); }, [data]);
+  return createElement("div", { ...rest, className, ref });
+}
 
 function decoration(attach: (el: HTMLSpanElement, opts: DrawablyOptions) => Sketch) {
   return function Decoration({ seed, roughness, boil, stroke, fill, paper, width, className, children, ...rest }: SpanProps): ReactElement {

--- a/src/rough.ts
+++ b/src/rough.ts
@@ -89,6 +89,24 @@ export function roughCircle(cx: number, cy: number, r: number, o: RoughOptions):
   return roughEllipse(cx, cy, r, r, o);
 }
 
+/** Clockwise angles in radians, measured from the positive x axis. */
+export function roughPieSlice(
+  cx: number, cy: number, r: number, start: number, end: number, o: RoughOptions,
+): string {
+  if (![cx, cy, r, start, end].every(Number.isFinite) || r < 0)
+    throw new Error("drawably: pie geometry must be finite with a non-negative radius");
+  const sweep = end - start;
+  if (r === 0 || sweep <= 0) return "";
+  if (sweep >= Math.PI * 2) return roughCircle(cx, cy, r, o);
+  // Match the renderer's 8px sampling while retaining the radial corners.
+  const arc = arcPoints(cx, cy, r, start, end, Math.max(2, Math.ceil(r * sweep / 8)));
+  const first = arc[0], last = arc[arc.length - 1];
+  return doubleStroke([
+    ...sampleLine(cx, cy, ...first), ...arc,
+    ...sampleLine(...last, cx, cy), [cx, cy],
+  ], o, true);
+}
+
 export function roughEllipse(
   cx: number,
   cy: number,

--- a/style.css
+++ b/style.css
@@ -418,3 +418,49 @@
 .drawably-pager > button {
   min-width: 34px;
 }
+
+/* Charts reserve space in HTML; their SVG remains decorative chrome. */
+.drawably-pie-chart {
+  min-width: 0;
+}
+
+.drawably-pie-plot {
+  width: 100%;
+  aspect-ratio: 1;
+  font: inherit;
+}
+
+.drawably-pie-label, .drawably-pie-empty {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  white-space: nowrap;
+}
+
+.drawably-pie-label {
+  padding: 0.1em 0.3em;
+  border-radius: 50%;
+  background: var(--drawably-paper, #e3e3e1);
+}
+
+.drawably-pie-empty { left: 50%; top: 50%; }
+
+.drawably-pie-legend {
+  list-style: none;
+  margin: 1em 0 0;
+  padding: 0;
+}
+
+.drawably-pie-legend li { display: flex; align-items: baseline; gap: 0.6em; margin: 0.4em 0; overflow-wrap: anywhere; }
+.drawably-pie-legend li > span:last-child { min-width: 0; }
+.drawably-pie-swatch { flex: 0 0 0.65em; height: 0.65em; background: var(--drawably-ink); border-radius: 43% 51% 40% 48%; }
+
+.drawably-pie-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,6 +4,8 @@ import * as drawably from "../src/index.js";
 it("exports the public surface", () => {
   for (const name of [
     "drawablyButton",
+    "drawablyPieChart",
+    "roughPieSlice",
     "drawablyCheckbox",
     "drawablyInput",
     "drawablyCard",

--- a/tests/pie.test.ts
+++ b/tests/pie.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { drawablyPieChart, type DrawablyPieDatum, type DrawablyPieChartOptions } from "../src/controls.js";
+import { roughCircle, roughPieSlice } from "../src/rough.js";
+
+const data = [
+  { label: "Overexcitement and frustration", value: 60 },
+  { label: "Learned habit", value: 40 },
+  { label: "Fear", value: 0 },
+  { label: "Aggression", value: 0 },
+];
+const cleanups: (() => void)[] = [];
+function mount(options: Partial<DrawablyPieChartOptions> = {}) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const sketch = drawablyPieChart(host, { data, seed: 42, ...options });
+  cleanups.push(() => { sketch.destroy(); host.remove(); });
+  return { host, sketch };
+}
+function paths(host: Element) {
+  return [...host.querySelectorAll(".drawably-outline")].map(p => p.getAttribute("d"));
+}
+afterEach(() => { cleanups.splice(0).forEach(fn => fn()); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+describe("roughPieSlice", () => {
+  const o = { seed: 42, roughness: 1, boil: 0 };
+  it("uses seeded, closed double strokes and the existing full circle", () => {
+    const d = roughPieSlice(100, 100, 90, 0, Math.PI, o);
+    expect(d).toBe(roughPieSlice(100, 100, 90, 0, Math.PI, o));
+    expect(d).not.toBe(roughPieSlice(100, 100, 90, 0, Math.PI, { ...o, seed: 1 }));
+    expect(d.match(/M/g)).toHaveLength(2);
+    expect(d.match(/Z/g)).toHaveLength(2);
+    expect(roughPieSlice(100, 100, 90, 0, Math.PI * 2, o)).toBe(roughCircle(100, 100, 90, o));
+  });
+  it("handles empty and invalid geometry", () => {
+    expect(roughPieSlice(0, 0, 90, 0, 0, o)).toBe("");
+    expect(roughPieSlice(0, 0, 0, 0, 1, o)).toBe("");
+    expect(() => roughPieSlice(0, 0, -1, 0, 1, o)).toThrow();
+    expect(() => roughPieSlice(0, 0, 1, 0, Infinity, o)).toThrow();
+  });
+});
+
+describe("drawablyPieChart", () => {
+  it("rejects bad elements and data before modifying the host", () => {
+    expect(() => drawablyPieChart(null as unknown as HTMLElement, { data })).toThrow();
+    const host = document.createElement("div");
+    host.innerHTML = "<p>Keep me</p>";
+    for (const value of [-1, Infinity, NaN, "3"])
+      expect(() => drawablyPieChart(host, { data: [{ label: "bad", value }] as DrawablyPieDatum[] })).toThrow();
+    expect(() => drawablyPieChart(host, {} as DrawablyPieChartOptions)).toThrow();
+    expect(() => drawablyPieChart(host, { data, roughness: Infinity })).toThrow();
+    expect(host.innerHTML).toBe("<p>Keep me</p>");
+  });
+  it("draws only positive slices and retains zero values in accessible HTML", () => {
+    const { host } = mount();
+    expect(host.querySelectorAll(".drawably-pie-slice")).toHaveLength(2);
+    expect(host.querySelectorAll(".drawably-outline")).toHaveLength(6);
+    expect(host.querySelectorAll(".drawably-scribble")).toHaveLength(6);
+    expect(host.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+    expect([...host.querySelectorAll("li")].map(li => li.textContent)).toEqual(data.map(d => `${d.label}: ${d.value}%`));
+    expect(host.querySelector("clipPath path")?.getAttribute("d")).toContain(" 0 1 1 ");
+  });
+  it("has deterministic geometry across mounts, updates and resketches", () => {
+    const first = mount(), second = mount();
+    const initial = paths(first.host);
+    expect(initial).toEqual(paths(second.host));
+    first.sketch.resketch(7);
+    expect(paths(first.host)).not.toEqual(initial);
+    first.sketch.resketch(42);
+    expect(paths(first.host)).toEqual(initial);
+    first.sketch.setData([{ label: "Only", value: 1 }]);
+    first.sketch.setData(data);
+    expect(paths(first.host)).toEqual(initial);
+  });
+  it("uses unique clip IDs per chart and keeps all references local", () => {
+    const charts = [mount(), mount()];
+    const ids = charts.flatMap(({ host }) => [...host.querySelectorAll("clipPath")].map(p => p.id));
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const { host, sketch } of charts) {
+      sketch.setData(data);
+      for (const g of host.querySelectorAll("[clip-path]")) {
+        const id = g.getAttribute("clip-path")!.slice(5, -1);
+        expect(host.querySelector(`#${id}`)).not.toBeNull();
+      }
+    }
+  });
+  it("boil zero draws one static frame; hidden legends remain accessible", () => {
+    const { host } = mount({ boil: 0, showLegend: false });
+    expect(host.querySelectorAll(".drawably-outline")).toHaveLength(2);
+    expect(host.querySelector(".drawably-boil")).toBeNull();
+    const legend = host.querySelector("ul")!;
+    expect(legend.classList.contains("drawably-pie-hidden")).toBe(true);
+    expect(legend.hasAttribute("aria-hidden")).toBe(false);
+    expect(legend.textContent).toContain("Fear: 0%");
+  });
+  it("normalizes weights, including huge finite values, and preserves tiny nonzero labels", () => {
+    const { host, sketch } = mount({ data: [{ label: "A", value: 3 }, { label: "B", value: 1 }] });
+    expect(host.textContent).toContain("A: 75%");
+    sketch.setData([{ label: "A", value: Number.MAX_VALUE }, { label: "B", value: Number.MAX_VALUE }]);
+    expect(host.textContent).toContain("A: 50%");
+    expect(paths(host).join()).not.toMatch(/NaN|Infinity/);
+    sketch.setData([{ label: "A", value: 10000 }, { label: "B", value: 1 }]);
+    expect(host.textContent).toContain("B: <0.1%");
+  });
+  it("renders a full circle for one positive value and an empty state for all zeros", () => {
+    const { host, sketch } = mount({ data: [{ label: "Only", value: 1 }] });
+    expect(host.querySelector("clipPath circle")).not.toBeNull();
+    expect(host.textContent).toContain("100%");
+    sketch.setData([{ label: "Zero", value: 0 }]);
+    expect(host.querySelectorAll(".drawably-pie-slice")).toHaveLength(0);
+    expect(host.textContent).toContain("No data");
+    expect(host.textContent).toContain("Zero: 0%");
+    sketch.setData([]);
+    expect(host.textContent).toBe("No data");
+  });
+  it("copies input, renders labels as text and rejects invalid updates atomically", () => {
+    const input = [{ label: "<img src=x onerror=alert(1)>", value: 1 }];
+    const { host, sketch } = mount({ data: input });
+    expect(host.querySelector("img")).toBeNull();
+    input[0].value = 0;
+    sketch.resketch(42);
+    expect(host.textContent).toContain("100%");
+    const before = host.innerHTML;
+    expect(() => sketch.setData([{ label: "Bad", value: -1 }])).toThrow();
+    expect(host.innerHTML).toBe(before);
+  });
+  it("redraws on resize and cleans up observers, font listeners and owned content", () => {
+    let resize = () => {};
+    const disconnect = vi.fn(), observe = vi.fn();
+    vi.stubGlobal("ResizeObserver", class {
+      constructor(callback: () => void) { resize = callback; }
+      observe = observe;
+      disconnect = disconnect;
+    });
+    const { host, sketch } = mount();
+    const plot = host.querySelector<HTMLElement>(".drawably-pie-plot")!;
+    Object.defineProperty(plot, "clientWidth", { value: 420, configurable: true });
+    resize();
+    expect(host.querySelector("svg")?.getAttribute("viewBox")).toBe("0 0 420 420");
+    const child = document.createElement("p"); child.textContent = "Preserved"; host.append(child);
+    const fonts = document.fonts && vi.spyOn(document.fonts, "removeEventListener");
+    sketch.destroy(); sketch.destroy(); resize(); sketch.resketch(1); sketch.setData(data);
+    expect(disconnect).toHaveBeenCalled();
+    if (fonts) expect(fonts).toHaveBeenCalledWith("loadingdone", expect.any(Function));
+    expect(host.innerHTML).toBe("<p>Preserved</p>");
+  });
+});

--- a/tests/react.test.tsx
+++ b/tests/react.test.tsx
@@ -1,10 +1,29 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, expect, it } from "vitest";
-import { useRef } from "react";
+import { useRef, StrictMode } from "react";
+import { DrawablyPieChart } from "../src/react.js";
 import { DrawablyArrow, DrawablyBadge, DrawablyButton, DrawablyCheckbox, DrawablyCircle, DrawablyHighlight, DrawablyList, DrawablySelect, DrawablyTextarea, DrawablyUnderline } from "../src/react.js";
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+it("DrawablyPieChart updates data, forwards native props and cleans up in StrictMode", () => {
+  const data = [{ label: "A", value: 60 }, { label: "B", value: 40 }];
+  const render = (values = data, className = "first") => act(() => root.render(
+    <StrictMode><DrawablyPieChart data={values} seed={42} boil={0} className={className} aria-label="Reasons" /></StrictMode>,
+  ));
+  render();
+  expect(host.querySelectorAll(".drawably-pie-chart")).toHaveLength(1);
+  expect(host.querySelector("[aria-label=Reasons]")?.className).toBe("first");
+  const original = host.querySelector(".drawably-outline")?.getAttribute("d");
+  render([{ label: "A", value: 25 }, { label: "B", value: 75 }]);
+  expect(host.textContent).toContain("A: 25%");
+  render(data, "second");
+  expect(host.querySelector(".drawably-outline")?.getAttribute("d")).toBe(original);
+  expect(host.querySelector("[aria-label=Reasons]")?.className).toBe("second");
+  act(() => root.render(<span />));
+  expect(host.querySelector("svg")).toBeNull();
+});
 
 let host: HTMLDivElement;
 let root: Root;


### PR DESCRIPTION
Adds a responsive pie chart built with Drawably's existing seeded pen renderer and scribbled fills. `drawablyPieChart()` and `DrawablyPieChart` accept labelled numeric weights; a 60/40/0/0 dataset draws two slices while preserving all four percentages in an accessible HTML legend.

The new `roughPieSlice()` generator supports the existing roughness and CSS boil settings. The chart supports data updates, re-sketching, custom-property colours, reduced motion, and cleanup. Empty/all-zero data shows an empty state; one positive value draws a full circle. Small wedges keep their values in the legend to avoid crowded interior labels.

Includes vanilla and React documentation, the main example, and an interactive pie-chart example. No runtime dependencies or package version changes.

Validation:
- `npm run build` and `npm run check` pass.
- `npm test`: 113 tests pass across 9 files, including geometry, deterministic redraws, zero/invalid data, unique clip IDs, resize/cleanup, and React StrictMode updates.
- `npm run pack:check` passes.
- Browser-checked at desktop and 360px widths: editing values, re-sketching, hiding the legend, and all-zero data.

The local macOS test installation required manually restoring the lockfile's missing optional `@rolldown/binding-darwin-arm64@1.2.4` binary; package manifests and the lockfile are unchanged.
